### PR TITLE
Connect OAuth token to app

### DIFF
--- a/Backend/README.md
+++ b/Backend/README.md
@@ -1,1 +1,28 @@
+## 백엔드 실행 가이드
 
+이 디렉터리에는 Spring Boot 기반의 서버 코드가 들어 있습니다. 개발용 데이터베이스로 MySQL을 사용하며, 실행 전에 `application.yml` 파일의 설정을 확인하세요.
+
+### 필수 환경
+
+- JDK 17 이상
+- MySQL 8.x
+
+### 실행 방법
+
+1. 프로젝트 루트에서 다음 명령어를 실행합니다.
+
+   ```bash
+   ./gradlew bootRun
+   ```
+
+2. 서버가 8080 포트에서 실행되며, 필요 시 `application.yml`에서 포트를 변경할 수 있습니다.
+
+### 주요 API
+
+- `POST /api/auth/signup` 회원가입
+- `POST /api/auth/login` 로그인
+- `GET /api/food/search?keyword=` 음식 검색
+- `GET /api/food/{id}` 음식 상세 조회
+- `GET /api/food/today` 오늘의 추천 식단
+- `/oauth2/authorization/google` 구글 로그인 시작
+   - 로그인 성공 시 `opensource-team6://oauth` 스킴으로 토큰을 전달합니다.

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/food/controller/FoodController.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/food/controller/FoodController.java
@@ -75,4 +75,13 @@ public class FoodController {
             return ResponseEntity.internalServerError().body(error);
         }
     }
+
+    /**
+     * 오늘의 추천 식단 조회
+     */
+    @GetMapping("/today")
+    public ResponseEntity<?> getTodayFoods() {
+        Map<String, List<FoodDTO>> meals = foodService.getTodayFoods();
+        return ResponseEntity.ok(meals);
+    }
 }

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/food/service/FoodService.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/food/service/FoodService.java
@@ -4,7 +4,11 @@ import lombok.RequiredArgsConstructor;
 import opensource_project_team6.recommend_diet.domain.food.dto.FoodDTO;
 import opensource_project_team6.recommend_diet.domain.food.entity.Food;
 import opensource_project_team6.recommend_diet.domain.food.repository.FoodRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,6 +35,22 @@ public class FoodService {
     public FoodDTO getFoodById(Long id) {
         Optional<Food> food = foodRepository.findById(id);
         return food.map(this::convertToDTO).orElse(null);
+    }
+
+    /**
+     * 오늘의 추천 식단 (임시 데이터)
+     */
+    public Map<String, List<FoodDTO>> getTodayFoods() {
+        List<Food> foods = foodRepository.findAll(PageRequest.of(0, 9)).getContent();
+        List<FoodDTO> dtos = foods.stream()
+                .map(this::convertToDTO)
+                .collect(Collectors.toList());
+
+        Map<String, List<FoodDTO>> result = new HashMap<>();
+        result.put("breakfast", dtos.subList(0, Math.min(3, dtos.size())));
+        result.put("lunch", dtos.subList(Math.min(3, dtos.size()), Math.min(6, dtos.size())));
+        result.put("dinner", dtos.subList(Math.min(6, dtos.size()), dtos.size()));
+        return result;
     }
 
     private FoodDTO convertToDTO(Food food) {

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/global/oauth/GoogleOAuth2SuccessHandler.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/global/oauth/GoogleOAuth2SuccessHandler.java
@@ -70,10 +70,10 @@ public class GoogleOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
           response.sendRedirect("http://localhost:3000/oauth2/success");
         * */
 
-        // json으로 응답 프론트에서 토큰을 꺼내어서 localStorage에 저장
-        response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write("{\"token\": \"" + token + "\"}");
-        response.getWriter().flush();
+        // 안드로이드 앱에서 처리할 수 있도록 커스텀 스킴으로 리다이렉트
+        String redirectUrl = "opensource-team6://oauth?token=" + token +
+                "&complete=" + isProfileComplete;
+        response.sendRedirect(redirectUrl);
 
         log.info("✅ [구글 로그인] JWT 발급 완료 - 토큰 값: {}", token);
     }

--- a/Frontend/README.md
+++ b/Frontend/README.md
@@ -1,0 +1,25 @@
+## 프론트엔드 실행 가이드
+
+이 디렉터리는 Android Studio 프로젝트입니다. 에뮬레이터나 실제 기기에서 앱을 실행하여 백엔드와 통신합니다.
+
+### 필수 환경
+
+- Android Studio Hedgehog 이상
+- Android SDK 35
+
+### 실행 방법
+
+1. Android Studio에서 `Frontend` 폴더를 열어 프로젝트를 로드합니다.
+2. 백엔드 주소는 `ApiConfig` 클래스의 `BASE_URL` 값을 수정해 설정합니다.
+
+   - `app/src/main/java/com/example/opensource_team6/network/ApiConfig.java`
+
+   기본 값은 `http://10.0.2.2:8080`이며, 실제 배포 서버 주소로 변경할 수 있습니다.
+3. 에뮬레이터 또는 연결된 기기에서 **Run**을 눌러 앱을 빌드하고 실행합니다.
+
+### 구글 로그인 사용법
+
+로그인 화면의 구글 버튼을 누르면 외부 브라우저에서 OAuth2 인증을 진행합니다.
+인증이 성공하면 백엔드가 `opensource-team6://oauth` 스킴으로 리다이렉트하며
+토큰이 앱으로 전달됩니다. 앱은 해당 토큰을 자동으로 저장한 뒤 메인 화면으로
+이동합니다.

--- a/Frontend/app/src/main/AndroidManifest.xml
+++ b/Frontend/app/src/main/AndroidManifest.xml
@@ -18,6 +18,17 @@
             android:exported="true"/>
 
         <activity
+            android:name=".login.ui.OAuthRedirectActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="opensource-team6" android:host="oauth" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".MainActivity"
             android:exported="true"/>
 

--- a/Frontend/app/src/main/java/com/example/opensource_team6/login/ui/LoginActivity.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/login/ui/LoginActivity.java
@@ -1,6 +1,7 @@
 package com.example.opensource_team6.login.ui;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -12,6 +13,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.example.opensource_team6.MainActivity;
 import com.example.opensource_team6.R;
 import com.example.opensource_team6.register.*;
+import com.example.opensource_team6.network.ApiConfig;
 
 public class LoginActivity extends AppCompatActivity {
 
@@ -82,7 +84,8 @@ public class LoginActivity extends AppCompatActivity {
 
         // 구글 로그인 버튼 클릭
         googleLogin.setOnClickListener(v -> {
-            Toast.makeText(this, "구글 로그인은 추후 연동됩니다.", Toast.LENGTH_SHORT).show();
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(ApiConfig.GOOGLE_LOGIN_URL));
+            startActivity(intent);
         });
 
         // 텍스트 변경 감지 (예시)

--- a/Frontend/app/src/main/java/com/example/opensource_team6/login/ui/OAuthRedirectActivity.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/login/ui/OAuthRedirectActivity.java
@@ -1,0 +1,29 @@
+package com.example.opensource_team6.login.ui;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.opensource_team6.MainActivity;
+import com.example.opensource_team6.util.TokenManager;
+
+public class OAuthRedirectActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        Uri uri = getIntent().getData();
+        if (uri != null && uri.getQueryParameter("token") != null) {
+            String token = uri.getQueryParameter("token");
+            TokenManager.saveToken(this, token);
+            Toast.makeText(this, "구글 로그인 완료", Toast.LENGTH_SHORT).show();
+            startActivity(new Intent(this, MainActivity.class));
+        } else {
+            Toast.makeText(this, "로그인 실패", Toast.LENGTH_SHORT).show();
+        }
+        finish();
+    }
+}

--- a/Frontend/app/src/main/java/com/example/opensource_team6/network/ApiConfig.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/network/ApiConfig.java
@@ -1,0 +1,6 @@
+package com.example.opensource_team6.network;
+
+public class ApiConfig {
+    public static final String BASE_URL = "http://10.0.2.2:8080"; // 백엔드 서버 주소
+    public static final String GOOGLE_LOGIN_URL = BASE_URL + "/oauth2/authorization/google";
+}

--- a/Frontend/app/src/main/java/com/example/opensource_team6/register/SignupStep2Activity.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/register/SignupStep2Activity.java
@@ -13,6 +13,7 @@ import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
 import com.example.opensource_team6.R;
 import com.example.opensource_team6.login.ui.LoginActivity;
+import com.example.opensource_team6.network.ApiConfig;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -79,7 +80,7 @@ public class SignupStep2Activity extends AppCompatActivity {
                 return;
             }
 
-            String url = "https://your-api-url.com/signup"; // 실제 엔드포인트로 변경 필요
+            String url = ApiConfig.BASE_URL + "/api/auth/signup"; // 백엔드 엔드포인트
 
             JsonObjectRequest request = new JsonObjectRequest(
                     Request.Method.POST,

--- a/Frontend/app/src/main/java/com/example/opensource_team6/today/TodayFragment.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/today/TodayFragment.java
@@ -19,6 +19,7 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
 import com.example.opensource_team6.R;
+import com.example.opensource_team6.network.ApiConfig;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -53,7 +54,7 @@ public class TodayFragment extends Fragment {
 
 
     private void fetchData() {
-        String url = "https://today-meals"; // <-- 실제 엔드포인트로 대체
+        String url = ApiConfig.BASE_URL + "/api/food/today"; // 오늘 식단 조회
 
         RequestQueue queue = Volley.newRequestQueue(requireContext());
 

--- a/Frontend/app/src/main/java/com/example/opensource_team6/util/TokenManager.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/util/TokenManager.java
@@ -1,0 +1,24 @@
+package com.example.opensource_team6.util;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public class TokenManager {
+    private static final String PREF_NAME = "AuthPrefs";
+    private static final String KEY_TOKEN = "token";
+
+    public static void saveToken(Context context, String token) {
+        SharedPreferences prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+        prefs.edit().putString(KEY_TOKEN, token).apply();
+    }
+
+    public static String getToken(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+        return prefs.getString(KEY_TOKEN, null);
+    }
+
+    public static void clearToken(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+        prefs.edit().remove(KEY_TOKEN).apply();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,3 +2,40 @@
 
 > 📋 [Notion 페이지 바로가기](https://www.notion.so/Team6-1f5aac2f706f8068ad8dfb5fe7ce981e)  
 > 팀 작업 상황을 확인하고 팀 링크와 문서를 관리하는 노션 페이지입니다.
+
+## ✅ 프로젝트 실행 매뉴얼
+
+아래 단계에 따라 백엔드와 프론트엔드를 실행하고 서로 연동할 수 있습니다.
+
+### 1. 백엔드(Spring Boot) 실행 방법
+
+1. JDK 17과 MySQL이 설치되어 있어야 합니다.
+2. `Backend/recommend-diet` 디렉터리로 이동합니다.
+3. 필요한 경우 `src/main/resources/application.yml`의 데이터베이스 정보와 OAuth 설정을 수정합니다.
+4. 다음 명령어로 서버를 실행합니다.
+
+   ```bash
+   ./gradlew bootRun
+   ```
+
+   기본 포트는 `8080`이며, 실행 후 `http://localhost:8080`에서 서버를 확인할 수 있습니다.
+
+### 2. 프론트엔드(Android) 실행 방법
+
+1. Android Studio에서 `Frontend` 디렉터리를 엽니다.
+2. 백엔드 서버 주소는 `ApiConfig` 클래스에서 설정합니다.
+
+   - `app/src/main/java/com/example/opensource_team6/network/ApiConfig.java`
+
+   기본 값은 `http://10.0.2.2:8080`으로, 필요에 따라 실제 서버 주소로 변경합니다.
+3. 에뮬레이터나 실제 기기에서 앱을 실행합니다.
+
+### 3. 구글 로그인 연동
+
+구글 로그인 버튼을 누르면 브라우저가 열리고 OAuth2 인증을 거친 뒤
+`opensource-team6://oauth` 주소로 리다이렉트됩니다. 앱은 이 주소를
+통해 전달된 JWT 토큰을 자동 저장하여 로그인 과정을 완료합니다.
+
+### 4. 백엔드와 프론트엔드 연동
+
+백엔드 서버가 실행된 상태에서, 프론트엔드 코드에 설정한 URL을 통해 API 요청이 이루어집니다. 두 프로젝트가 동일한 네트워크 내에 있어야 하며, 개발 환경에서는 위의 예시처럼 `10.0.2.2` 주소를 사용하면 됩니다.


### PR DESCRIPTION
## Summary
- 백엔드 구글 OAuth 성공 시 앱 스킴으로 리다이렉트
- 안드로이드에서 토큰을 저장하는 `TokenManager` 추가
- 토큰을 받아 메인 화면으로 이동하는 `OAuthRedirectActivity` 구현
- 인텐트 필터를 통해 커스텀 스킴 처리
- README에 변경된 로그인 흐름 설명 추가

## Testing
- `bash ./gradlew test` (backend) 실패
- `bash ./gradlew test` (frontend) 실패

------
https://chatgpt.com/codex/tasks/task_e_6841e439a5ec833092d694a3886a1592