### PR TITLE
Fetch real profile data

### DIFF
--- a/Frontend/app/src/main/java/com/example/opensource_team6/profile/ProfileFragment.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/profile/ProfileFragment.java
@@ -2,19 +2,89 @@
 package com.example.opensource_team6.profile;
 
 import android.os.Bundle;
-import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
+import android.widget.Toast;
 
+import androidx.fragment.app.Fragment;
+
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.toolbox.JsonObjectRequest;
+import com.android.volley.toolbox.Volley;
 import com.example.opensource_team6.R;
+import com.example.opensource_team6.network.ApiConfig;
+import com.example.opensource_team6.util.TokenManager;
+
+import org.json.JSONObject;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class ProfileFragment extends Fragment {
+
+    private TextView profileName;
+    private TextView profileTag;
+    private TextView profileDesc;
+
     public ProfileFragment() {}
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        return inflater.inflate(R.layout.profile_fragment, container, false);
+        View view = inflater.inflate(R.layout.profile_fragment, container, false);
+
+        profileName = view.findViewById(R.id.profile_name);
+        profileTag = view.findViewById(R.id.profile_tag);
+        profileDesc = view.findViewById(R.id.profile_desc);
+
+        fetchProfile();
+
+        return view;
+    }
+
+    private void fetchProfile() {
+        String token = TokenManager.getToken(requireContext());
+        if (token == null) {
+            Toast.makeText(getContext(), "로그인이 필요합니다.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        String url = ApiConfig.BASE_URL + "/api/user/mypage";
+
+        JsonObjectRequest request = new JsonObjectRequest(
+                Request.Method.GET,
+                url,
+                null,
+                response -> updateProfile(response),
+                error -> Toast.makeText(getContext(), "프로필 정보를 가져오지 못했습니다.", Toast.LENGTH_SHORT).show()
+        ) {
+            @Override
+            public Map<String, String> getHeaders() {
+                Map<String, String> headers = new HashMap<>();
+                headers.put("Authorization", "Bearer " + token);
+                return headers;
+            }
+        };
+
+        RequestQueue queue = Volley.newRequestQueue(requireContext());
+        queue.add(request);
+    }
+
+    private void updateProfile(JSONObject response) {
+        String name = response.optString("name");
+        String gender = response.optString("gender");
+        String birthDate = response.optString("birthDate");
+        int age = response.optInt("age", -1);
+
+        profileName.setText(name);
+        profileTag.setText("성별: " + gender);
+        if (age >= 0) {
+            profileDesc.setText("생년월일: " + birthDate + " (" + age + "세)");
+        } else {
+            profileDesc.setText("생년월일: " + birthDate);
+        }
     }
 }


### PR DESCRIPTION
## 변경 내용
- 프로필 화면에서 백엔드 API를 호출해 실제 사용자 정보를 표시하도록 수정했습니다.
- 토큰을 읽어 `Authorization` 헤더에 추가하여 `/api/user/mypage` 엔드포인트를 요청합니다.
- 응답 데이터로 이름, 성별, 생년월일 및 나이를 화면에 반영합니다.

## 테스트 결과
- `./gradlew assembleDebug` 명령을 실행했으나, Android SDK 경로가 없어 빌드에 실패했습니다. 자세한 내용은 아래 로그를 참고하세요.


------
https://chatgpt.com/codex/tasks/task_e_6852e4ff57ac8330b23d9534dc2ff5bf