### PR TITLE
Add daily diet lookup on home

### DIFF
--- a/Frontend/app/src/main/res/layout/home_fragment.xml
+++ b/Frontend/app/src/main/res/layout/home_fragment.xml
@@ -92,6 +92,13 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:text="저녁"/>
+
+            <Button
+                android:id="@+id/btnSnack"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="간식"/>
         </LinearLayout>
 
         <!-- 아침 카드 그룹 -->
@@ -115,6 +122,15 @@
         <!-- 저녁 카드 그룹 -->
         <LinearLayout
             android:id="@+id/groupDinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginTop="16dp"
+            android:visibility="gone" />
+
+        <!-- 간식 카드 그룹 -->
+        <LinearLayout
+            android:id="@+id/groupSnack"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"


### PR DESCRIPTION
## 요약
- 홈 화면에서 날짜 선택 시 서버에서 식단을 조회하도록 기능 추가
- 간식 포함 네 가지 식사별 레이아웃 및 버튼 추가

## 테스트
- `./gradlew test` 실행 시 JDK 부재로 실패

------
https://chatgpt.com/codex/tasks/task_e_6852f3ca2aec83309cebf829fa2a5c40