### PR TITLE
Add diet score graph to profile

### DIFF
--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/diet/controller/DietContaroller.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/diet/controller/DietContaroller.java
@@ -75,4 +75,20 @@ public class DietContaroller {
         response.put("data", result);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/score")
+    public ResponseEntity<?> getDietScore(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                          @RequestParam("date") String dateStr) {
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        LocalDate date = LocalDate.parse(dateStr);
+        var result = dietService.getDietScore(user, date);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", 200);
+        response.put("message", "점수 계산 성공");
+        response.put("data", result);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/myPage/dto/DietScoreResponse.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/myPage/dto/DietScoreResponse.java
@@ -1,0 +1,9 @@
+package opensource_project_team6.recommend_diet.domain.myPage.dto;
+
+public record DietScoreResponse(
+        double carbScore,
+        double proteinScore,
+        double fatScore,
+        double finalScore,
+        String message
+) {}

--- a/Frontend/app/src/main/res/layout/profile_fragment.xml
+++ b/Frontend/app/src/main/res/layout/profile_fragment.xml
@@ -148,7 +148,7 @@
     <LinearLayout
         android:id="@+id/score_section"
         android:layout_width="match_parent"
-        android:layout_height="250dp"
+        android:layout_height="wrap_content"
         android:orientation="vertical"
         android:layout_below="@id/profile_section"
         android:padding="24dp">
@@ -161,11 +161,71 @@
             android:textColor="#3399FF"
             android:textStyle="bold" />
 
-        <!-- 바 그래프는 CustomView나 RecyclerView로 따로 구현 필요 -->
-        <ImageView
+        <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="200dp"
-            android:src="@drawable/sample_graph" />
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginTop="8dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="탄수화물" />
+            <ProgressBar
+                android:id="@+id/progress_carb"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="16dp"
+                android:max="100"
+                android:progress="0"
+                android:progressDrawable="@drawable/custom_progress_bar" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="단백질"
+                android:layout_marginTop="8dp" />
+            <ProgressBar
+                android:id="@+id/progress_protein"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="16dp"
+                android:max="100"
+                android:progress="0"
+                android:progressDrawable="@drawable/custom_progress_bar" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="지방"
+                android:layout_marginTop="8dp" />
+            <ProgressBar
+                android:id="@+id/progress_fat"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="16dp"
+                android:max="100"
+                android:progress="0"
+                android:progressDrawable="@drawable/custom_progress_bar" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/final_score_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="점수: 0"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:layout_marginTop="12dp" />
+
+        <TextView
+            android:id="@+id/score_message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=""
+            android:textSize="14sp"
+            android:textColor="#444444"
+            android:layout_marginTop="4dp" />
     </LinearLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
## 요약
- 식단 점수를 계산해 주는 API 추가
- 프로필 화면 하단에 탄단지 점수와 최종 점수 표시
- 점수에 따른 응원 문구 출력

## 테스트
- `./gradlew test` 실행 시 JDK 자동 다운로드가 제한되어 실패했습니다.

------
https://chatgpt.com/codex/tasks/task_e_68531ce918288330aecfee3c8c1c7c14