### PR TITLE
Add meal photo capture feature

### DIFF
--- a/Frontend/app/src/main/AndroidManifest.xml
+++ b/Frontend/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:allowBackup="true"
@@ -68,6 +69,19 @@
         <activity android:name=".register.SignupStep1Activity" />
 
         <activity android:name=".register.SignupStep2Activity" />
+
+        <activity android:name=".MealPhotoActivity" />
+        <activity android:name=".MealPhotoHistoryActivity" />
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
         <activity android:name=".profile.ProfileFragment" />
 

--- a/Frontend/app/src/main/java/com/example/opensource_team6/MainActivity.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/MainActivity.java
@@ -2,7 +2,6 @@ package com.example.opensource_team6;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
@@ -38,7 +37,8 @@ public class MainActivity extends AppCompatActivity {
                 startActivity(intent);
                 return true;
             } else if (id == R.id.nav_scan) {
-                Toast.makeText(this, "식단 사진 클릭됨", Toast.LENGTH_SHORT).show();
+                Intent intent = new Intent(this, MealPhotoActivity.class);
+                startActivity(intent);
                 return true;
             } else if (id == R.id.nav_profile) {
                 selected = new ProfileFragment();

--- a/Frontend/app/src/main/java/com/example/opensource_team6/MealPhotoActivity.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/MealPhotoActivity.java
@@ -1,0 +1,82 @@
+package com.example.opensource_team6;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.ImageView;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.FileProvider;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class MealPhotoActivity extends AppCompatActivity {
+    private ImageView imgBreakfast, imgLunch, imgDinner, imgSnack;
+    private final Map<String, ActivityResultLauncher<Uri>> launchers = new HashMap<>();
+    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd", Locale.getDefault());
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_meal_photo);
+
+        imgBreakfast = findViewById(R.id.imgBreakfast);
+        imgLunch = findViewById(R.id.imgLunch);
+        imgDinner = findViewById(R.id.imgDinner);
+        imgSnack = findViewById(R.id.imgSnack);
+        Button btnHistory = findViewById(R.id.btnHistory);
+
+        registerLauncher("breakfast", imgBreakfast);
+        registerLauncher("lunch", imgLunch);
+        registerLauncher("dinner", imgDinner);
+        registerLauncher("snack", imgSnack);
+
+        btnHistory.setOnClickListener(v -> startActivity(new Intent(this, MealPhotoHistoryActivity.class)));
+
+        loadTodayPhotos();
+    }
+
+    private void registerLauncher(String meal, ImageView view) {
+        ActivityResultLauncher<Uri> launcher = registerForActivityResult(new ActivityResultContracts.TakePicture(), success -> {
+            if (success) loadTodayPhotos();
+        });
+        launchers.put(meal, launcher);
+        view.setOnClickListener(v -> {
+            Uri uri = getPhotoUri(meal);
+            launcher.launch(uri);
+        });
+    }
+
+    private Uri getPhotoUri(String meal) {
+        File dir = new File(getExternalFilesDir(null), "meal_photos");
+        if (!dir.exists()) dir.mkdirs();
+        String date = dateFormat.format(new Date());
+        File file = new File(dir, date + "_" + meal + ".jpg");
+        return FileProvider.getUriForFile(this, getPackageName() + ".fileprovider", file);
+    }
+
+    private void loadTodayPhotos() {
+        String date = dateFormat.format(new Date());
+        File dir = new File(getExternalFilesDir(null), "meal_photos");
+        setImage(imgBreakfast, new File(dir, date + "_breakfast.jpg"));
+        setImage(imgLunch, new File(dir, date + "_lunch.jpg"));
+        setImage(imgDinner, new File(dir, date + "_dinner.jpg"));
+        setImage(imgSnack, new File(dir, date + "_snack.jpg"));
+    }
+
+    private void setImage(ImageView view, File file) {
+        if (file.exists()) {
+            view.setImageURI(Uri.fromFile(file));
+        } else {
+            view.setImageResource(android.R.drawable.ic_menu_camera);
+        }
+    }
+}

--- a/Frontend/app/src/main/java/com/example/opensource_team6/MealPhotoHistoryActivity.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/MealPhotoHistoryActivity.java
@@ -1,0 +1,40 @@
+package com.example.opensource_team6;
+
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import java.io.File;
+import java.util.Arrays;
+
+public class MealPhotoHistoryActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_meal_photo_history);
+
+        LinearLayout historyList = findViewById(R.id.historyList);
+        File dir = new File(getExternalFilesDir(null), "meal_photos");
+        if (!dir.exists()) return;
+
+        File[] files = dir.listFiles();
+        if (files == null) return;
+        Arrays.sort(files, (a, b) -> Long.compare(b.lastModified(), a.lastModified()));
+
+        for (File f : files) {
+            TextView tv = new TextView(this);
+            tv.setText(f.getName());
+            ImageView iv = new ImageView(this);
+            iv.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+            iv.setAdjustViewBounds(true);
+            iv.setImageURI(Uri.fromFile(f));
+            historyList.addView(tv);
+            historyList.addView(iv);
+        }
+    }
+}

--- a/Frontend/app/src/main/res/layout/activity_meal_photo.xml
+++ b/Frontend/app/src/main/res/layout/activity_meal_photo.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="오늘 식단 사진"
+            android:textStyle="bold"
+            android:textSize="18sp" />
+
+        <ImageView
+            android:id="@+id/imgBreakfast"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+
+        <ImageView
+            android:id="@+id/imgLunch"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+
+        <ImageView
+            android:id="@+id/imgDinner"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+
+        <ImageView
+            android:id="@+id/imgSnack"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+
+        <Button
+            android:id="@+id/btnHistory"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="이전 사진 보기"
+            android:layout_marginTop="16dp" />
+
+    </LinearLayout>
+</ScrollView>

--- a/Frontend/app/src/main/res/layout/activity_meal_photo_history.xml
+++ b/Frontend/app/src/main/res/layout/activity_meal_photo_history.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/historyList"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp" />
+</ScrollView>

--- a/Frontend/app/src/main/res/xml/file_paths.xml
+++ b/Frontend/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-files-path
+        name="meal_photos"
+        path="." />
+</paths>


### PR DESCRIPTION
## Summary
- allow camera usage with new permission
- handle 'meal photo' menu via new activities
- store meal photos per-meal and show history

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew -p Backend/recommend-diet test` *(fails: Java toolchain missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853253a11cc8330a53e72c4567acfee