### PR TITLE
Add simple follow system

### DIFF
--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/follow/controller/FollowController.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/follow/controller/FollowController.java
@@ -1,0 +1,53 @@
+package opensource_project_team6.recommend_diet.domain.follow.controller;
+
+import lombok.RequiredArgsConstructor;
+import opensource_project_team6.recommend_diet.domain.follow.dto.UserSimpleResponse;
+import opensource_project_team6.recommend_diet.domain.follow.service.FollowService;
+import opensource_project_team6.recommend_diet.global.util.UserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Controller
+@RequestMapping("/api/follow")
+@RequiredArgsConstructor
+public class FollowController {
+    private final FollowService followService;
+
+    @PostMapping("/{targetId}")
+    public ResponseEntity<Map<String, Object>> follow(@AuthenticationPrincipal UserPrincipal user,
+                                                      @PathVariable Long targetId) {
+        followService.follow(user.getId(), targetId);
+        return ResponseEntity.ok(Map.of("status", 200, "message", "followed"));
+    }
+
+    @DeleteMapping("/{targetId}")
+    public ResponseEntity<Map<String, Object>> unfollow(@AuthenticationPrincipal UserPrincipal user,
+                                                        @PathVariable Long targetId) {
+        followService.unfollow(user.getId(), targetId);
+        return ResponseEntity.ok(Map.of("status", 200, "message", "unfollowed"));
+    }
+
+    @GetMapping("/followers/{userId}")
+    public ResponseEntity<Map<String, Object>> followers(@PathVariable Long userId) {
+        List<UserSimpleResponse> list = followService.getFollowers(userId);
+        Map<String, Object> res = new HashMap<>();
+        res.put("status", 200);
+        res.put("data", list);
+        return ResponseEntity.ok(res);
+    }
+
+    @GetMapping("/followings/{userId}")
+    public ResponseEntity<Map<String, Object>> followings(@PathVariable Long userId) {
+        List<UserSimpleResponse> list = followService.getFollowings(userId);
+        Map<String, Object> res = new HashMap<>();
+        res.put("status", 200);
+        res.put("data", list);
+        return ResponseEntity.ok(res);
+    }
+}

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/follow/dto/UserSimpleResponse.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/follow/dto/UserSimpleResponse.java
@@ -1,0 +1,3 @@
+package opensource_project_team6.recommend_diet.domain.follow.dto;
+
+public record UserSimpleResponse(Long id, String name) {}

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/follow/entity/Follow.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/follow/entity/Follow.java
@@ -1,0 +1,26 @@
+package opensource_project_team6.recommend_diet.domain.follow.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import opensource_project_team6.recommend_diet.domain.user.entity.User;
+
+@Entity
+@Table(name = "follow", uniqueConstraints = @UniqueConstraint(columnNames = {"follower_id", "following_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Follow {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id")
+    private User follower;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id")
+    private User following;
+}

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/follow/repository/FollowRepository.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,14 @@
+package opensource_project_team6.recommend_diet.domain.follow.repository;
+
+import opensource_project_team6.recommend_diet.domain.follow.entity.Follow;
+import opensource_project_team6.recommend_diet.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    Optional<Follow> findByFollowerAndFollowing(User follower, User following);
+    List<Follow> findAllByFollower(User follower);
+    List<Follow> findAllByFollowing(User following);
+}

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/follow/service/FollowService.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/follow/service/FollowService.java
@@ -1,0 +1,51 @@
+package opensource_project_team6.recommend_diet.domain.follow.service;
+
+import lombok.RequiredArgsConstructor;
+import opensource_project_team6.recommend_diet.domain.follow.dto.UserSimpleResponse;
+import opensource_project_team6.recommend_diet.domain.follow.entity.Follow;
+import opensource_project_team6.recommend_diet.domain.follow.repository.FollowRepository;
+import opensource_project_team6.recommend_diet.domain.user.entity.User;
+import opensource_project_team6.recommend_diet.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+
+    public void follow(Long followerId, Long followingId) {
+        if (followerId.equals(followingId)) return;
+        User follower = userRepository.findById(followerId).orElseThrow();
+        User following = userRepository.findById(followingId).orElseThrow();
+        followRepository.findByFollowerAndFollowing(follower, following)
+                .orElseGet(() -> followRepository.save(Follow.builder()
+                        .follower(follower)
+                        .following(following)
+                        .build()));
+    }
+
+    public void unfollow(Long followerId, Long followingId) {
+        User follower = userRepository.findById(followerId).orElseThrow();
+        User following = userRepository.findById(followingId).orElseThrow();
+        followRepository.findByFollowerAndFollowing(follower, following)
+                .ifPresent(followRepository::delete);
+    }
+
+    public List<UserSimpleResponse> getFollowers(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        return followRepository.findAllByFollowing(user).stream()
+                .map(f -> new UserSimpleResponse(f.getFollower().getId(), f.getFollower().getName()))
+                .collect(Collectors.toList());
+    }
+
+    public List<UserSimpleResponse> getFollowings(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        return followRepository.findAllByFollower(user).stream()
+                .map(f -> new UserSimpleResponse(f.getFollowing().getId(), f.getFollowing().getName()))
+                .collect(Collectors.toList());
+    }
+}

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/user/controller/UserController.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/user/controller/UserController.java
@@ -1,0 +1,44 @@
+package opensource_project_team6.recommend_diet.domain.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import opensource_project_team6.recommend_diet.domain.follow.dto.UserSimpleResponse;
+import opensource_project_team6.recommend_diet.domain.user.repository.UserRepository;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/user")
+public class UserController {
+    private final UserRepository userRepository;
+
+    @GetMapping("/search")
+    public ResponseEntity<Map<String, Object>> search(@RequestParam String name) {
+        List<UserSimpleResponse> list = userRepository.findByNameContaining(name).stream()
+                .map(u -> new UserSimpleResponse(u.getId(), u.getName()))
+                .collect(Collectors.toList());
+        Map<String, Object> res = new HashMap<>();
+        res.put("status", 200);
+        res.put("data", list);
+        return ResponseEntity.ok(res);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Map<String, Object>> getUser(@PathVariable Long id) {
+        return userRepository.findById(id)
+                .map(u -> ResponseEntity.ok(Map.of(
+                        "status", 200,
+                        "data", new UserSimpleResponse(u.getId(), u.getName())
+                )))
+                .orElseGet(() -> ResponseEntity.status(404).body(Map.of("status", 404)));
+    }
+}

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/user/repository/UserRepository.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/user/repository/UserRepository.java
@@ -9,4 +9,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByGoogleId(String googleId);
     Optional<User> findByEmail(String email);
     Boolean existsByEmail(String email);
+    java.util.List<User> findByNameContaining(String name);
 }

--- a/Frontend/app/src/main/java/com/example/opensource_team6/profile/ProfileFragment.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/profile/ProfileFragment.java
@@ -8,6 +8,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.ImageButton;
+import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.AutoCompleteTextView;
 import android.widget.ArrayAdapter;
@@ -47,6 +48,10 @@ public class ProfileFragment extends Fragment {
     private TextView followingText;
     private Button followButton;
     private AutoCompleteTextView userSearch;
+    private Button searchButton;
+    private ImageView followerImg1;
+    private ImageView followerImg2;
+    private ImageView followerImg3;
     private TextView followerPlus;
     private TextView followerNames;
     private int userId = 1; // default current user
@@ -70,6 +75,10 @@ public class ProfileFragment extends Fragment {
         followingText = view.findViewById(R.id.following);
         followButton = view.findViewById(R.id.btn_follow);
         userSearch = view.findViewById(R.id.user_search);
+        searchButton = view.findViewById(R.id.user_search_button);
+        followerImg1 = view.findViewById(R.id.follower_img1);
+        followerImg2 = view.findViewById(R.id.follower_img2);
+        followerImg3 = view.findViewById(R.id.follower_img3);
         followerPlus = view.findViewById(R.id.follower_plus);
         followerNames = view.findViewById(R.id.follower_names);
 
@@ -80,6 +89,23 @@ public class ProfileFragment extends Fragment {
             String name = adapter.getItem(position);
             User target = UserRepository.getUserByName(name);
             if (target != null) openProfile(target.getId());
+        });
+        searchButton.setOnClickListener(v -> {
+            String query = userSearch.getText().toString();
+            java.util.List<User> matches = new java.util.ArrayList<>();
+            for (User u : UserRepository.getUsers()) {
+                if (u.getName().contains(query)) matches.add(u);
+            }
+            if (matches.isEmpty()) {
+                Toast.makeText(getContext(), "검색 결과가 없습니다", Toast.LENGTH_SHORT).show();
+            } else {
+                CharSequence[] items = new CharSequence[matches.size()];
+                for (int i = 0; i < matches.size(); i++) items[i] = matches.get(i).getName();
+                new androidx.appcompat.app.AlertDialog.Builder(requireContext())
+                        .setTitle("검색 결과")
+                        .setItems(items, (d, which) -> openProfile(matches.get(which).getId()))
+                        .show();
+            }
         });
         Bundle args = getArguments();
         if (args != null) userId = args.getInt("userId", 1);
@@ -210,12 +236,15 @@ public class ProfileFragment extends Fragment {
 
         StringBuilder names = new StringBuilder();
         int count = 0;
+        ImageView[] imgs = {followerImg1, followerImg2, followerImg3};
+        for (ImageView img : imgs) img.setVisibility(View.GONE);
         for (int id : followers) {
             User u = UserRepository.getUserById(id);
             if (u == null) continue;
             if (count < 3) {
                 if (names.length() > 0) names.append(", ");
                 names.append(u.getName());
+                imgs[count].setVisibility(View.VISIBLE);
             }
             count++;
         }

--- a/Frontend/app/src/main/java/com/example/opensource_team6/user/FollowManager.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/user/FollowManager.java
@@ -1,0 +1,73 @@
+package com.example.opensource_team6.user;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class FollowManager {
+    private static final String PREF = "FollowPrefs";
+
+    private static SharedPreferences prefs(Context ctx) {
+        return ctx.getSharedPreferences(PREF, Context.MODE_PRIVATE);
+    }
+
+    private static Set<String> getSet(Context ctx, String key) {
+        return new HashSet<>(prefs(ctx).getStringSet(key, new HashSet<>()));
+    }
+
+    private static void saveSet(Context ctx, String key, Set<String> set) {
+        prefs(ctx).edit().putStringSet(key, set).apply();
+    }
+
+    public static Set<Integer> getFollowers(Context ctx, int userId) {
+        Set<String> raw = getSet(ctx, "followers_" + userId);
+        Set<Integer> result = new HashSet<>();
+        for (String s : raw) result.add(Integer.parseInt(s));
+        return result;
+    }
+
+    public static Set<Integer> getFollowings(Context ctx, int userId) {
+        Set<String> raw = getSet(ctx, "following_" + userId);
+        Set<Integer> result = new HashSet<>();
+        for (String s : raw) result.add(Integer.parseInt(s));
+        return result;
+    }
+
+    private static void setFollowers(Context ctx, int userId, Set<Integer> set) {
+        Set<String> raw = new HashSet<>();
+        for (int id : set) raw.add(String.valueOf(id));
+        saveSet(ctx, "followers_" + userId, raw);
+    }
+
+    private static void setFollowings(Context ctx, int userId, Set<Integer> set) {
+        Set<String> raw = new HashSet<>();
+        for (int id : set) raw.add(String.valueOf(id));
+        saveSet(ctx, "following_" + userId, raw);
+    }
+
+    public static boolean isFollowing(Context ctx, int userId, int targetId) {
+        return getFollowings(ctx, userId).contains(targetId);
+    }
+
+    public static void follow(Context ctx, int userId, int targetId) {
+        Set<Integer> followings = getFollowings(ctx, userId);
+        Set<Integer> followers = getFollowers(ctx, targetId);
+        if (followings.add(targetId)) {
+            followers.add(userId);
+            setFollowings(ctx, userId, followings);
+            setFollowers(ctx, targetId, followers);
+        }
+    }
+
+    public static void unfollow(Context ctx, int userId, int targetId) {
+        Set<Integer> followings = getFollowings(ctx, userId);
+        Set<Integer> followers = getFollowers(ctx, targetId);
+        if (followings.remove(targetId)) {
+            followers.remove(userId);
+            setFollowings(ctx, userId, followings);
+            setFollowers(ctx, targetId, followers);
+        }
+    }
+}

--- a/Frontend/app/src/main/java/com/example/opensource_team6/user/User.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/user/User.java
@@ -1,0 +1,14 @@
+package com.example.opensource_team6.user;
+
+public class User {
+    private final int id;
+    private final String name;
+
+    public User(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public int getId() { return id; }
+    public String getName() { return name; }
+}

--- a/Frontend/app/src/main/java/com/example/opensource_team6/user/UserRepository.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/user/UserRepository.java
@@ -1,0 +1,28 @@
+package com.example.opensource_team6.user;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UserRepository {
+    private static final List<User> users = new ArrayList<>();
+    static {
+        users.add(new User(1, "박영현"));
+        users.add(new User(2, "비만"));
+        users.add(new User(3, "정삼"));
+        users.add(new User(4, "초 고도비만"));
+        users.add(new User(5, "테스트1"));
+        users.add(new User(6, "테스트2"));
+    }
+
+    public static List<User> getUsers() { return users; }
+
+    public static User getUserById(int id) {
+        for (User u : users) if (u.getId() == id) return u;
+        return null;
+    }
+
+    public static User getUserByName(String name) {
+        for (User u : users) if (u.getName().equals(name)) return u;
+        return null;
+    }
+}

--- a/Frontend/app/src/main/res/layout/profile_fragment.xml
+++ b/Frontend/app/src/main/res/layout/profile_fragment.xml
@@ -15,6 +15,15 @@
         android:src="@drawable/ic_settings"
         android:contentDescription="설정" />
 
+    <AutoCompleteTextView
+        android:id="@+id/user_search"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_below="@id/btn_settings"
+        android:hint="사용자 검색" />
+
     <!-- 프로필 섹션 -->
     <LinearLayout
         android:id="@+id/profile_section"
@@ -102,6 +111,15 @@
                 android:textColor="@color/color_primary" />
         </LinearLayout>
 
+        <Button
+            android:id="@+id/btn_follow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:backgroundTint="@color/color_accent"
+            android:textColor="@android:color/white"
+            android:text="팔로우" />
+
         <!-- 팔로우 목록 요약 -->
         <LinearLayout
             android:layout_width="match_parent"
@@ -110,35 +128,40 @@
             android:layout_marginTop="@dimen/spacing_normal">
 
             <ImageView
+                android:id="@+id/follower_img1"
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:src="@drawable/ic_user1"
                 android:layout_marginEnd="8dp" />
 
             <ImageView
+                android:id="@+id/follower_img2"
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:src="@drawable/ic_user1"
                 android:layout_marginEnd="8dp" />
 
             <ImageView
+                android:id="@+id/follower_img3"
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:src="@drawable/ic_user1"
                 android:layout_marginEnd="8dp" />
 
             <TextView
+                android:id="@+id/follower_plus"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="+100"
+                android:text="+0"
                 android:textColor="@color/color_primary"
                 android:textSize="@dimen/text_size_body"
                 android:layout_marginEnd="8dp" />
 
             <TextView
+                android:id="@+id/follower_names"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="비만, 정삼, 초 고도비만 외 100명"
+                android:text=""
                 android:textSize="@dimen/text_size_caption"
                 android:textColor="@color/color_secondary" />
         </LinearLayout>

--- a/Frontend/app/src/main/res/layout/profile_fragment.xml
+++ b/Frontend/app/src/main/res/layout/profile_fragment.xml
@@ -15,14 +15,28 @@
         android:src="@drawable/ic_settings"
         android:contentDescription="설정" />
 
-    <AutoCompleteTextView
-        android:id="@+id/user_search"
+    <LinearLayout
+        android:id="@+id/search_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
         android:layout_below="@id/btn_settings"
-        android:hint="사용자 검색" />
+        android:orientation="horizontal"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp">
+
+        <AutoCompleteTextView
+            android:id="@+id/user_search"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="사용자 검색" />
+
+        <Button
+            android:id="@+id/user_search_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="검색" />
+    </LinearLayout>
 
     <!-- 프로필 섹션 -->
     <LinearLayout
@@ -30,6 +44,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        android:layout_below="@id/search_container"
         android:padding="24dp">
 
         <!-- 프로필 이미지 및 텍스트 -->


### PR DESCRIPTION
## 변경 사항
- 프로필 화면에 사용자 검색창을 추가했습니다.
- 팔로우/팔로잉 정보를 로컬로 관리하도록 `FollowManager`와 `UserRepository`를 추가했습니다.
- 다른 사용자의 프로필을 열어 팔로우/언팔로우가 가능하도록 수정했습니다.

## 테스트
- `./gradlew assembleDebug` 명령을 실행했으나 Android SDK 설정이 없어 실패했습니다.

------
https://chatgpt.com/codex/tasks/task_e_6853efa161d883308ab72f7fa89ad7a1