### PR TITLE
Implement meal photo fragment

### DIFF
--- a/Frontend/app/src/main/java/com/example/opensource_team6/MainActivity.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/MainActivity.java
@@ -10,6 +10,7 @@ import com.example.opensource_team6.home.HomeFragment;
 import com.example.opensource_team6.profile.ProfileFragment;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.example.opensource_team6.today.TodayFragment;
+import com.example.opensource_team6.MealPhotoFragment;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -37,9 +38,7 @@ public class MainActivity extends AppCompatActivity {
                 startActivity(intent);
                 return true;
             } else if (id == R.id.nav_scan) {
-                Intent intent = new Intent(this, MealPhotoActivity.class);
-                startActivity(intent);
-                return true;
+                selected = new MealPhotoFragment();
             } else if (id == R.id.nav_profile) {
                 selected = new ProfileFragment();
             }

--- a/Frontend/app/src/main/java/com/example/opensource_team6/MealPhotoFragment.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/MealPhotoFragment.java
@@ -1,0 +1,95 @@
+package com.example.opensource_team6;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.core.content.FileProvider;
+import androidx.fragment.app.Fragment;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class MealPhotoFragment extends Fragment {
+    private ImageView imgBreakfast, imgLunch, imgDinner, imgSnack;
+    private final Map<String, ActivityResultLauncher<Uri>> launchers = new HashMap<>();
+    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd", Locale.getDefault());
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_meal_photo, container, false);
+
+        imgBreakfast = view.findViewById(R.id.imgBreakfast);
+        imgLunch = view.findViewById(R.id.imgLunch);
+        imgDinner = view.findViewById(R.id.imgDinner);
+        imgSnack = view.findViewById(R.id.imgSnack);
+        Button btnBreakfastHistory = view.findViewById(R.id.btnBreakfastHistory);
+        Button btnLunchHistory = view.findViewById(R.id.btnLunchHistory);
+        Button btnDinnerHistory = view.findViewById(R.id.btnDinnerHistory);
+
+        registerLauncher("breakfast", imgBreakfast);
+        registerLauncher("lunch", imgLunch);
+        registerLauncher("dinner", imgDinner);
+        registerLauncher("snack", imgSnack);
+
+        btnBreakfastHistory.setOnClickListener(v -> openHistory("breakfast"));
+        btnLunchHistory.setOnClickListener(v -> openHistory("lunch"));
+        btnDinnerHistory.setOnClickListener(v -> openHistory("dinner"));
+
+        loadTodayPhotos();
+        return view;
+    }
+
+    private void openHistory(String meal) {
+        Intent intent = new Intent(getActivity(), MealPhotoHistoryActivity.class);
+        intent.putExtra("meal", meal);
+        startActivity(intent);
+    }
+
+    private void registerLauncher(String meal, ImageView view) {
+        ActivityResultLauncher<Uri> launcher = registerForActivityResult(new ActivityResultContracts.TakePicture(), success -> {
+            if (success) loadTodayPhotos();
+        });
+        launchers.put(meal, launcher);
+        view.setOnClickListener(v -> {
+            Uri uri = getPhotoUri(meal);
+            launcher.launch(uri);
+        });
+    }
+
+    private Uri getPhotoUri(String meal) {
+        File dir = new File(requireContext().getExternalFilesDir(null), "meal_photos");
+        if (!dir.exists()) dir.mkdirs();
+        String date = dateFormat.format(new Date());
+        File file = new File(dir, date + "_" + meal + ".jpg");
+        return FileProvider.getUriForFile(requireContext(), requireContext().getPackageName() + ".fileprovider", file);
+    }
+
+    private void loadTodayPhotos() {
+        String date = dateFormat.format(new Date());
+        File dir = new File(requireContext().getExternalFilesDir(null), "meal_photos");
+        setImage(imgBreakfast, new File(dir, date + "_breakfast.jpg"));
+        setImage(imgLunch, new File(dir, date + "_lunch.jpg"));
+        setImage(imgDinner, new File(dir, date + "_dinner.jpg"));
+        setImage(imgSnack, new File(dir, date + "_snack.jpg"));
+    }
+
+    private void setImage(ImageView view, File file) {
+        if (file.exists()) {
+            view.setImageURI(Uri.fromFile(file));
+        } else {
+            view.setImageResource(android.R.drawable.ic_menu_camera);
+        }
+    }
+}

--- a/Frontend/app/src/main/java/com/example/opensource_team6/MealPhotoHistoryActivity.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/MealPhotoHistoryActivity.java
@@ -6,6 +6,10 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
 
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -19,6 +23,7 @@ public class MealPhotoHistoryActivity extends AppCompatActivity {
         setContentView(R.layout.activity_meal_photo_history);
 
         LinearLayout historyList = findViewById(R.id.historyList);
+        String meal = getIntent().getStringExtra("meal");
         File dir = new File(getExternalFilesDir(null), "meal_photos");
         if (!dir.exists()) return;
 
@@ -26,15 +31,35 @@ public class MealPhotoHistoryActivity extends AppCompatActivity {
         if (files == null) return;
         Arrays.sort(files, (a, b) -> Long.compare(b.lastModified(), a.lastModified()));
 
+        SimpleDateFormat df = new SimpleDateFormat("yyyyMMdd", Locale.getDefault());
+        long now = System.currentTimeMillis();
+        long sevenDays = 7L * 24 * 60 * 60 * 1000;
+        int count = 0;
+
         for (File f : files) {
+            String name = f.getName();
+            String[] parts = name.split("_");
+            if (parts.length != 2) continue;
+            String datePart = parts[0];
+            String mealPart = parts[1].replace(".jpg", "");
+            if (!mealPart.equals(meal)) continue;
+            try {
+                Date d = df.parse(datePart);
+                if (d == null) continue;
+                if (now - d.getTime() > sevenDays) continue;
+            } catch (ParseException e) {
+                continue;
+            }
             TextView tv = new TextView(this);
-            tv.setText(f.getName());
+            tv.setText(name);
             ImageView iv = new ImageView(this);
             iv.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
             iv.setAdjustViewBounds(true);
             iv.setImageURI(Uri.fromFile(f));
             historyList.addView(tv);
             historyList.addView(iv);
+            count++;
+            if (count >= 7) break;
         }
     }
 }

--- a/Frontend/app/src/main/res/layout/fragment_meal_photo.xml
+++ b/Frontend/app/src/main/res/layout/fragment_meal_photo.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="오늘 식단 사진"
+            android:textStyle="bold"
+            android:textSize="18sp" />
+
+        <ImageView
+            android:id="@+id/imgBreakfast"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+        <Button
+            android:id="@+id/btnBreakfastHistory"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="아침 기록"
+            android:layout_marginBottom="8dp" />
+
+        <ImageView
+            android:id="@+id/imgLunch"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+        <Button
+            android:id="@+id/btnLunchHistory"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="점심 기록"
+            android:layout_marginBottom="8dp" />
+
+        <ImageView
+            android:id="@+id/imgDinner"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+        <Button
+            android:id="@+id/btnDinnerHistory"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="저녁 기록"
+            android:layout_marginBottom="8dp" />
+
+        <ImageView
+            android:id="@+id/imgSnack"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## 변경 내용
- `MealPhotoActivity` 대신 `MealPhotoFragment`를 추가하여 하단 메뉴에서 프래그먼트로 이동하도록 수정
- 각 식사별 사진 기록 버튼을 추가하여 최근 7일간의 사진을 확인 가능하게 변경
- `MealPhotoHistoryActivity`에서 식사 타입과 7일 제한을 적용하도록 로직 수정

## 테스트
- `./gradlew test` 실행 시 SDK 경로 부재로 실패


------
https://chatgpt.com/codex/tasks/task_e_6853f06ebdf48330b6ad2715fbad75f6