### PR TITLE
간식 사진 조회 버튼 추가

### DIFF
--- a/Frontend/app/src/main/java/com/example/opensource_team6/MealPhotoFragment.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/MealPhotoFragment.java
@@ -1,0 +1,34 @@
+package com.example.opensource_team6;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+public class MealPhotoFragment extends Fragment {
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_meal_photo, container, false);
+
+        Button btnSnackHistory = view.findViewById(R.id.btnSnackHistory);
+        btnSnackHistory.setOnClickListener(v -> openHistory("snack"));
+
+        return view;
+    }
+
+    private void openHistory(String meal) {
+        if (getActivity() == null) return;
+        Intent intent = new Intent(getActivity(), MealPhotoHistoryActivity.class);
+        intent.putExtra("meal", meal);
+        startActivity(intent);
+    }
+}

--- a/Frontend/app/src/main/res/layout/fragment_meal_photo.xml
+++ b/Frontend/app/src/main/res/layout/fragment_meal_photo.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="오늘 식단 사진"
+            android:textStyle="bold"
+            android:textSize="18sp" />
+
+        <ImageView
+            android:id="@+id/imgBreakfast"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+
+        <ImageView
+            android:id="@+id/imgLunch"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+
+        <ImageView
+            android:id="@+id/imgDinner"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+
+        <ImageView
+            android:id="@+id/imgSnack"
+            android:layout_width="match_parent"
+            android:layout_height="200dp"
+            android:layout_marginTop="12dp"
+            android:scaleType="centerCrop"
+            android:src="@android:drawable/ic_menu_camera" />
+
+        <Button
+            android:id="@+id/btnHistory"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="이전 사진 보기"
+            android:layout_marginTop="16dp" />
+
+        <Button
+            android:id="@+id/btnSnackHistory"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="간식 사진 조회"
+            android:layout_marginTop="8dp" />
+
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
## 변경 내용
- `fragment_meal_photo.xml`에 간식 사진 조회 버튼을 배치했습니다.
- `MealPhotoFragment.java`에서 해당 버튼을 찾아 `openHistory("snack")`를 호출하도록 구현했습니다.

## 테스트
- 백엔드 Gradle 테스트 실행을 시도했으나 JDK 17 설정 부재로 빌드가 실패했습니다.

------
https://chatgpt.com/codex/tasks/task_e_6853f6eecd148330a30b599e889df55b