### PR TITLE
Add extra nutrition fields to AI food save

### DIFF
--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/diet/service/DietAiService.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/diet/service/DietAiService.java
@@ -20,8 +20,13 @@ public class DietAiService {
     private final UserRepository userRepository;
     private final DietRepository dietRepository;
 
-    public void addDietFromAi(Long userId, String name, double energy, double carbohydrate, double protein, double fat, double sugar, double sodium, double cholesterol, double saturatedFat, MealTime mealTime, double amount, LocalDate date) {
-        Food food = foodService.addRecognizedFood(name, energy, carbohydrate, protein, fat);
+    public void addDietFromAi(Long userId, String name, double energy,
+                              double carbohydrate, double protein, double fat,
+                              double sugar, double sodium,
+                              double cholesterol, double saturatedFat,
+                              MealTime mealTime, double amount, LocalDate date) {
+        Food food = foodService.addRecognizedFood(name, energy, carbohydrate, protein, fat,
+                sugar, sodium, cholesterol, saturatedFat);
         User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다"));
 
         // amount 기준으로 실제 섭취량 계산

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/food/controller/FoodController.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/food/controller/FoodController.java
@@ -48,8 +48,13 @@ public class FoodController {
             double carbohydrate = Double.parseDouble(payload.get("carbohydrate").toString());
             double protein = Double.parseDouble(payload.get("protein").toString());
             double fat = Double.parseDouble(payload.get("fat").toString());
+            double sugar = Double.parseDouble(payload.get("sugar").toString());
+            double sodium = Double.parseDouble(payload.get("sodium").toString());
+            double cholesterol = Double.parseDouble(payload.get("cholesterol").toString());
+            double saturatedFat = Double.parseDouble(payload.get("saturatedFat").toString());
 
-            FoodDTO dto = foodService.addRecognizedFood(name, energy, carbohydrate, protein, fat);
+            FoodDTO dto = foodService.addRecognizedFood(name, energy, carbohydrate, protein, fat,
+                    sugar, sodium, cholesterol, saturatedFat);
             return ResponseEntity.ok(Map.of(
                     "message", "AI 인식 음식 추가 완료",
                     "data", dto

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/food/service/FoodService.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/food/service/FoodService.java
@@ -35,7 +35,10 @@ public class FoodService {
                 .collect(Collectors.toList());
     }
 
-    public Food addRecognizedFood(String name, double energy, double carbohydrate, double protein, double fat) {
+    public Food addRecognizedFood(String name, double energy, double carbohydrate,
+                                  double protein, double fat,
+                                  double sugar, double sodium,
+                                  double cholesterol, double saturatedFat) {
         String newName = name + "_사진";
 
         if (foodRepository.findByName(newName).isPresent()) {
@@ -53,10 +56,10 @@ public class FoodService {
                 .carbohydrate(carbohydrate)
                 .protein(protein)
                 .fat(fat)
-                .sugar(0.0)
-                .sodium(0.0)
-                .cholesterol(0.0)
-                .saturatedFat(0.0)
+                .sugar(sugar)
+                .sodium(sodium)
+                .cholesterol(cholesterol)
+                .saturatedFat(saturatedFat)
                 .build();
 
         return foodRepository.save(food);

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/food/service/OpenAIService.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/food/service/OpenAIService.java
@@ -117,6 +117,10 @@ public class OpenAIService {
                 .carbohydrate(result.path("carbohydrate").asDouble())
                 .protein(result.path("protein").asDouble())
                 .fat(result.path("fat").asDouble())
+                .cholesterol(result.path("cholesterol").asDouble())
+                .saturatedFat(result.path("saturated_fat").asDouble())
+                .sodium(result.path("sodium").asDouble())
+                .sugar(result.path("sugar").asDouble())
                 .build();
 
         return food;


### PR DESCRIPTION
## 변경 내용
- OpenAI 분석 결과에서 콜레스테롤, 포화지방, 나트륨, 당 정보를 함께 저장하도록 수정
- AI 인식 음식 저장 메서드에 추가 영양 정보를 반영
- AI 식단 서비스에서도 새로운 파라미터 사용
- 컨트롤러 예시 코드 주석 내부도 업데이트

## 테스트 결과
- `./gradlew test` 실행 시 데이터베이스 연결 오류로 테스트 실패


------
https://chatgpt.com/codex/tasks/task_e_685458dc80fc8330aee43afffee90a81