### PR TITLE
Improve meal photo layout

### DIFF
--- a/Frontend/app/src/main/res/layout/activity_meal_photo.xml
+++ b/Frontend/app/src/main/res/layout/activity_meal_photo.xml
@@ -16,37 +16,46 @@
             android:textStyle="bold"
             android:textSize="18sp" />
 
-        <ImageView
-            android:id="@+id/imgBreakfast"
+        <androidx.gridlayout.widget.GridLayout
             android:layout_width="match_parent"
-            android:layout_height="200dp"
+            android:layout_height="wrap_content"
+            android:columnCount="2"
             android:layout_marginTop="12dp"
-            android:scaleType="centerCrop"
-            android:src="@android:drawable/ic_menu_camera" />
+            android:useDefaultMargins="true">
 
-        <ImageView
-            android:id="@+id/imgLunch"
-            android:layout_width="match_parent"
-            android:layout_height="200dp"
-            android:layout_marginTop="12dp"
-            android:scaleType="centerCrop"
-            android:src="@android:drawable/ic_menu_camera" />
+            <ImageView
+                android:id="@+id/imgBreakfast"
+                android:layout_width="0dp"
+                android:layout_height="150dp"
+                android:layout_columnWeight="1"
+                android:scaleType="centerCrop"
+                android:src="@android:drawable/ic_menu_camera" />
 
-        <ImageView
-            android:id="@+id/imgDinner"
-            android:layout_width="match_parent"
-            android:layout_height="200dp"
-            android:layout_marginTop="12dp"
-            android:scaleType="centerCrop"
-            android:src="@android:drawable/ic_menu_camera" />
+            <ImageView
+                android:id="@+id/imgLunch"
+                android:layout_width="0dp"
+                android:layout_height="150dp"
+                android:layout_columnWeight="1"
+                android:scaleType="centerCrop"
+                android:src="@android:drawable/ic_menu_camera" />
 
-        <ImageView
-            android:id="@+id/imgSnack"
-            android:layout_width="match_parent"
-            android:layout_height="200dp"
-            android:layout_marginTop="12dp"
-            android:scaleType="centerCrop"
-            android:src="@android:drawable/ic_menu_camera" />
+            <ImageView
+                android:id="@+id/imgDinner"
+                android:layout_width="0dp"
+                android:layout_height="150dp"
+                android:layout_columnWeight="1"
+                android:scaleType="centerCrop"
+                android:src="@android:drawable/ic_menu_camera" />
+
+            <ImageView
+                android:id="@+id/imgSnack"
+                android:layout_width="0dp"
+                android:layout_height="150dp"
+                android:layout_columnWeight="1"
+                android:scaleType="centerCrop"
+                android:src="@android:drawable/ic_menu_camera" />
+
+        </androidx.gridlayout.widget.GridLayout>
 
         <Button
             android:id="@+id/btnHistory"

--- a/Frontend/app/src/main/res/layout/fragment_meal_photo.xml
+++ b/Frontend/app/src/main/res/layout/fragment_meal_photo.xml
@@ -16,76 +16,115 @@
             android:textStyle="bold"
             android:textSize="18sp" />
 
-        <ImageView
-            android:id="@+id/imgBreakfast"
+        <androidx.gridlayout.widget.GridLayout
             android:layout_width="match_parent"
-            android:layout_height="200dp"
+            android:layout_height="wrap_content"
+            android:columnCount="2"
             android:layout_marginTop="12dp"
-            android:scaleType="centerCrop"
-            android:src="@android:drawable/ic_menu_camera" />
+            android:useDefaultMargins="true">
 
-        <Button
-            android:id="@+id/btnBreakfastHistory"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="아침 기록"
-            android:layout_marginBottom="4dp" />
-        <Button
-            android:id="@+id/btnBreakfastAnalyze"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="AI 영상성분 인식"
-            android:layout_marginBottom="8dp" />
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:orientation="vertical">
 
-        <ImageView
-            android:id="@+id/imgLunch"
-            android:layout_width="match_parent"
-            android:layout_height="200dp"
-            android:layout_marginTop="12dp"
-            android:scaleType="centerCrop"
-            android:src="@android:drawable/ic_menu_camera" />
-      
-        <Button
-            android:id="@+id/btnLunchHistory"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="점심 기록"
-            android:layout_marginBottom="4dp" />
-        <Button
-            android:id="@+id/btnLunchAnalyze"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="AI 영상성분 인식"
-            android:layout_marginBottom="8dp" />
+                <ImageView
+                    android:id="@+id/imgBreakfast"
+                    android:layout_width="match_parent"
+                    android:layout_height="150dp"
+                    android:scaleType="centerCrop"
+                    android:src="@android:drawable/ic_menu_camera" />
 
-        <ImageView
-            android:id="@+id/imgDinner"
-            android:layout_width="match_parent"
-            android:layout_height="200dp"
-            android:layout_marginTop="12dp"
-            android:scaleType="centerCrop"
-            android:src="@android:drawable/ic_menu_camera" />
+                <Button
+                    android:id="@+id/btnBreakfastHistory"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="아침 기록"
+                    android:layout_marginBottom="4dp" />
+                <Button
+                    android:id="@+id/btnBreakfastAnalyze"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="AI 영상성분 인식"
+                    android:layout_marginBottom="8dp" />
+            </LinearLayout>
 
-        <Button
-            android:id="@+id/btnDinnerHistory"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="저녁 기록"
-            android:layout_marginBottom="4dp" />
-        <Button
-            android:id="@+id/btnDinnerAnalyze"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="AI 영상성분 인식"
-            android:layout_marginBottom="8dp" />
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:orientation="vertical">
 
-        <ImageView
-            android:id="@+id/imgSnack"
-            android:layout_width="match_parent"
-            android:layout_height="200dp"
-            android:layout_marginTop="12dp"
-            android:scaleType="centerCrop"
-            android:src="@android:drawable/ic_menu_camera" />
+                <ImageView
+                    android:id="@+id/imgLunch"
+                    android:layout_width="match_parent"
+                    android:layout_height="150dp"
+                    android:scaleType="centerCrop"
+                    android:src="@android:drawable/ic_menu_camera" />
+
+                <Button
+                    android:id="@+id/btnLunchHistory"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="점심 기록"
+                    android:layout_marginBottom="4dp" />
+                <Button
+                    android:id="@+id/btnLunchAnalyze"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="AI 영상성분 인식"
+                    android:layout_marginBottom="8dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:id="@+id/imgDinner"
+                    android:layout_width="match_parent"
+                    android:layout_height="150dp"
+                    android:scaleType="centerCrop"
+                    android:src="@android:drawable/ic_menu_camera" />
+
+                <Button
+                    android:id="@+id/btnDinnerHistory"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="저녁 기록"
+                    android:layout_marginBottom="4dp" />
+                <Button
+                    android:id="@+id/btnDinnerAnalyze"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="AI 영상성분 인식"
+                    android:layout_marginBottom="8dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_columnWeight="1"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:id="@+id/imgSnack"
+                    android:layout_width="match_parent"
+                    android:layout_height="150dp"
+                    android:scaleType="centerCrop"
+                    android:src="@android:drawable/ic_menu_camera" />
+
+                <Button
+                    android:id="@+id/btnSnackHistory"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="간식 사진 조회"
+                    android:layout_marginTop="8dp" />
+            </LinearLayout>
+        </androidx.gridlayout.widget.GridLayout>
 
         <Button
             android:id="@+id/btnHistory"
@@ -93,13 +132,6 @@
             android:layout_height="wrap_content"
             android:text="이전 사진 보기"
             android:layout_marginTop="16dp" />
-
-        <Button
-            android:id="@+id/btnSnackHistory"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="간식 사진 조회"
-            android:layout_marginTop="8dp" />
 
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
## 변경 내용
- 오늘 식단 사진을 갤러리 형식으로 표시하도록 레이아웃 수정
- MealPhotoActivity와 MealPhotoFragment의 레이아웃을 GridLayout을 사용하도록 변경

## 테스트 결과
- 백엔드 `./gradlew test` 실행 시 JDK가 없어 실패함

------
https://chatgpt.com/codex/tasks/task_e_68545a268cf88330b925fceafb23c04d