### PR TITLE
Fix high recommended amounts in profile

### DIFF
--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/diet/service/DietService.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/diet/service/DietService.java
@@ -115,6 +115,10 @@ public class DietService {
         double proteinRatio = user.getTargetProteinRatio() != null ? user.getTargetProteinRatio() : 0;
         double fatRatio = user.getTargetFatRatio() != null ? user.getTargetFatRatio() : 0;
 
+        if (carbRatio > 1) carbRatio /= 100.0;
+        if (proteinRatio > 1) proteinRatio /= 100.0;
+        if (fatRatio > 1) fatRatio /= 100.0;
+
         double recommendedEnergy = calculateBmr(user);
         double recCarb = recommendedEnergy * carbRatio / 4.0;
         double recProtein = recommendedEnergy * proteinRatio / 4.0;

--- a/Frontend/app/src/main/java/com/example/opensource_team6/profile/SettingsActivity.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/profile/SettingsActivity.java
@@ -46,9 +46,9 @@ public class SettingsActivity extends AppCompatActivity {
 
             JSONObject data = new JSONObject();
             try {
-                if (carb != null) data.put("carbRatio", carb);
-                if (protein != null) data.put("proteinRatio", protein);
-                if (fat != null) data.put("fatRatio", fat);
+                if (carb != null) data.put("carbRatio", carb / 100.0);
+                if (protein != null) data.put("proteinRatio", protein / 100.0);
+                if (fat != null) data.put("fatRatio", fat / 100.0);
             } catch (JSONException e) {
                 Toast.makeText(this, "데이터 오류", Toast.LENGTH_SHORT).show();
                 return;


### PR DESCRIPTION
## Summary
- correct user macro ratio submission
- interpret ratio over 1 as percentage on server side

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies of task)*

------
https://chatgpt.com/codex/tasks/task_e_685460156b948330802fae57dd8188ad