### PR TITLE
Add diet calculation fragment

### DIFF
--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/myPage/dto/MyPageResponse.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/myPage/dto/MyPageResponse.java
@@ -7,6 +7,9 @@ public record MyPageResponse(
         String gender,
         LocalDate birthDate,
         int age,
+        Integer height,
+        Double weight,
+        Double targetWeight,
         String profileImageUrl,
         long followerCount,
         long follwingCount

--- a/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/myPage/service/MyPageService.java
+++ b/Backend/recommend-diet/src/main/java/opensource_project_team6/recommend_diet/domain/myPage/service/MyPageService.java
@@ -36,6 +36,9 @@ public class MyPageService {
                 user.getGender(),
                 user.getBirthDate(),
                 age,
+                user.getHeight() != null ? user.getHeight().intValue() : null,
+                user.getWeight(),
+                user.getTargetWeight(),
                 imageUrl,
                 followerCount,
                 followingCount

--- a/Frontend/app/build.gradle.kts
+++ b/Frontend/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
 }
 
 android {
@@ -30,6 +31,9 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
     }
     buildFeatures {
         viewBinding = true

--- a/Frontend/app/src/main/java/com/example/opensource_team6/MainActivity.java
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/MainActivity.java
@@ -1,6 +1,5 @@
 package com.example.opensource_team6;
 
-import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -9,8 +8,8 @@ import androidx.fragment.app.Fragment;
 import com.example.opensource_team6.home.HomeFragment;
 import com.example.opensource_team6.profile.ProfileFragment;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
-import com.example.opensource_team6.today.TodayFragment;
 import com.example.opensource_team6.MealPhotoFragment;
+import com.example.opensource_team6.diet.DietCalcFragment;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -33,10 +32,7 @@ public class MainActivity extends AppCompatActivity {
             if (id == R.id.nav_home) {
                 selected = new HomeFragment();
             } else if (id == R.id.nav_diary) {
-                //selected = new TodayFragment();
-                Intent intent = new Intent(this, TodayMealActivity.class);
-                startActivity(intent);
-                return true;
+                selected = new DietCalcFragment();
             } else if (id == R.id.nav_scan) {
                 selected = new MealPhotoFragment();
             } else if (id == R.id.nav_profile) {

--- a/Frontend/app/src/main/java/com/example/opensource_team6/diet/DietCalcFragment.kt
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/diet/DietCalcFragment.kt
@@ -1,0 +1,69 @@
+package com.example.opensource_team6.diet
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.example.opensource_team6.databinding.FragmentDietCalcBinding
+
+class DietCalcFragment : Fragment() {
+    private var _binding: FragmentDietCalcBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: DietViewModel by viewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentDietCalcBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        ArrayAdapter.createFromResource(
+            requireContext(),
+            com.example.opensource_team6.R.array.activity_level_options,
+            android.R.layout.simple_spinner_item
+        ).also { adapter ->
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            binding.spinnerActivity.adapter = adapter
+        }
+
+        viewModel.userInfo.observe(viewLifecycleOwner) { user ->
+            user?.let {
+                binding.textUserInfo.text = "${it.name} | 키 ${it.height}cm, 현재 ${it.currentWeight}kg / 목표 ${it.targetWeight}kg, ${it.age}세"
+            }
+        }
+
+        binding.buttonCalc.setOnClickListener {
+            val period = binding.editGoalPeriod.text.toString().toIntOrNull()
+            if (period == null || period <= 0) {
+                Toast.makeText(requireContext(), "목표 기간을 입력하세요", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            val item = binding.spinnerActivity.selectedItem.toString()
+            val level = item.substringAfter('(').substringBefore(')').toDoubleOrNull() ?: 1.2
+            val result = viewModel.calculate(period, level)
+            if (result == null) {
+                Toast.makeText(requireContext(), "사용자 정보를 불러오지 못했습니다", Toast.LENGTH_SHORT).show()
+                return@setOnClickListener
+            }
+            binding.textCalories.text = "하루 권장: ${result.dailyCalories} kcal"
+            binding.textCarb.text = "탄수화물: ${result.carbKcal} kcal / ${result.carbGram} g"
+            binding.textProtein.text = "단백질: ${result.proteinKcal} kcal / ${result.proteinGram} g"
+            binding.textFat.text = "지방: ${result.fatKcal} kcal / ${result.fatGram} g"
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/Frontend/app/src/main/java/com/example/opensource_team6/diet/DietViewModel.kt
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/diet/DietViewModel.kt
@@ -1,0 +1,53 @@
+package com.example.opensource_team6.diet
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+
+class DietViewModel(application: Application) : AndroidViewModel(application) {
+    private val repository = UserInfoRepository(application.applicationContext)
+
+    private val _userInfo = MutableLiveData<UserInfo?>()
+    val userInfo: LiveData<UserInfo?> = _userInfo
+
+    init {
+        repository.fetchUserInfo { info ->
+            _userInfo.postValue(info)
+        }
+    }
+
+    data class Result(
+        val dailyCalories: Int,
+        val carbKcal: Int,
+        val carbGram: Int,
+        val proteinKcal: Int,
+        val proteinGram: Int,
+        val fatKcal: Int,
+        val fatGram: Int
+    )
+
+    fun calculate(goalPeriodDays: Int, activityLevel: Double): Result? {
+        val user = _userInfo.value ?: return null
+        val bmr = if (user.gender == "male") {
+            10 * user.currentWeight + 6.25 * user.height - 5 * user.age + 5
+        } else {
+            10 * user.currentWeight + 6.25 * user.height - 5 * user.age - 161
+        }
+        val tdee = bmr * activityLevel
+        val totalLoss = (user.currentWeight - user.targetWeight) * 7700
+        val dailyCal = tdee - (totalLoss / goalPeriodDays)
+        val carbKcal = dailyCal * 0.5
+        val proteinKcal = dailyCal * 0.3
+        val fatKcal = dailyCal * 0.2
+        return Result(
+            dailyCal.toInt(),
+            carbKcal.toInt(),
+            (carbKcal / 4).toInt(),
+            proteinKcal.toInt(),
+            (proteinKcal / 4).toInt(),
+            fatKcal.toInt(),
+            (fatKcal / 9).toInt()
+        )
+    }
+}

--- a/Frontend/app/src/main/java/com/example/opensource_team6/diet/UserInfo.kt
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/diet/UserInfo.kt
@@ -1,0 +1,10 @@
+package com.example.opensource_team6.diet
+
+data class UserInfo(
+    val name: String?,
+    val gender: String,
+    val currentWeight: Double,
+    val targetWeight: Double,
+    val height: Int,
+    val age: Int
+)

--- a/Frontend/app/src/main/java/com/example/opensource_team6/diet/UserInfoRepository.kt
+++ b/Frontend/app/src/main/java/com/example/opensource_team6/diet/UserInfoRepository.kt
@@ -1,0 +1,36 @@
+package com.example.opensource_team6.diet
+
+import android.content.Context
+import com.android.volley.Request
+import com.android.volley.toolbox.JsonObjectRequest
+import com.android.volley.toolbox.Volley
+import com.example.opensource_team6.network.ApiConfig
+import com.example.opensource_team6.util.TokenManager
+
+class UserInfoRepository(private val context: Context) {
+    fun fetchUserInfo(callback: (UserInfo?) -> Unit) {
+        val token = TokenManager.getToken(context) ?: run {
+            callback(null)
+            return
+        }
+        val url = ApiConfig.BASE_URL + "/api/user/mypage"
+        val req = object : JsonObjectRequest(Method.GET, url, null, { res ->
+            val info = UserInfo(
+                res.optString("name"),
+                res.optString("gender"),
+                res.optDouble("weight"),
+                res.optDouble("targetWeight"),
+                res.optInt("height"),
+                res.optInt("age")
+            )
+            callback(info)
+        }, { _ -> callback(null) }) {
+            override fun getHeaders(): MutableMap<String, String> {
+                val headers = HashMap<String, String>()
+                headers["Authorization"] = "Bearer $token"
+                return headers
+            }
+        }
+        Volley.newRequestQueue(context).add(req)
+    }
+}

--- a/Frontend/app/src/main/res/layout/fragment_diet_calc.xml
+++ b/Frontend/app/src/main/res/layout/fragment_diet_calc.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/textUserInfo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="사용자 정보 로딩 중..."
+            android:textSize="16sp"
+            android:paddingBottom="8dp" />
+
+        <EditText
+            android:id="@+id/editGoalPeriod"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="목표 기간(일)"
+            android:inputType="number" />
+
+        <Spinner
+            android:id="@+id/spinnerActivity"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp" />
+
+        <Button
+            android:id="@+id/buttonCalc"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="계산하기"
+            android:layout_marginTop="8dp" />
+
+        <TextView
+            android:id="@+id/textCalories"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:layout_marginTop="16dp" />
+
+        <TextView
+            android:id="@+id/textCarb"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/textProtein"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/textFat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+</ScrollView>

--- a/Frontend/app/src/main/res/values/strings.xml
+++ b/Frontend/app/src/main/res/values/strings.xml
@@ -40,4 +40,12 @@
         <item>소화 문제</item>
         <item>없음</item>
     </string-array>
+
+    <string-array name="activity_level_options">
+        <item>거의 활동 없음 (1.2)</item>
+        <item>가벼운 활동 (주 1~3회) (1.375)</item>
+        <item>중간 활동 (주 3~5회) (1.55)</item>
+        <item>격렬한 활동 (주 6~7회) (1.725)</item>
+        <item>매우 격렬한 활동 (1.9)</item>
+    </string-array>
 </resources>

--- a/Frontend/gradle/libs.versions.toml
+++ b/Frontend/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ constraintlayout = "2.2.1"
 annotation = "1.6.0"
 lifecycleLivedataKtx = "2.6.1"
 lifecycleViewmodelKtx = "2.6.1"
+kotlin = "1.9.22"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -25,4 +26,5 @@ lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-view
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 

--- a/Frontend/settings.gradle.kts
+++ b/Frontend/settings.gradle.kts
@@ -12,6 +12,7 @@ pluginManagement {
     }
     plugins {
         id("com.android.application") version "8.2.2"
+        id("org.jetbrains.kotlin.android") version "1.9.22"
     }
 }
 dependencyResolutionManagement {


### PR DESCRIPTION
## 요약
- Kotlin 플러그인 추가 및 설정 수정
- 사용자 정보를 불러오는 `UserInfoRepository`와 이를 사용하는 `DietViewModel` 작성
- 목표 기간과 활동량을 입력해 권장 칼로리를 계산하는 `DietCalcFragment` 구현
- 활동 계수 스피너 항목 및 레이아웃 추가

## 테스트
- `./gradlew assembleDebug` 실행 시 Android SDK 부재로 빌드 실패


------
https://chatgpt.com/codex/tasks/task_e_685461bcc04083308c1cfffe0cf7a594